### PR TITLE
cleanup pause/stop workflow

### DIFF
--- a/python/cs_GUI.enaml
+++ b/python/cs_GUI.enaml
@@ -292,9 +292,6 @@ enamldef CsMenuBar(MenuBar): menuBar:
                 checkable = True
                 text = 'After Error'
                 checked := experiment.pauseAfterError
-            Action:
-                text = 'Now\tCtrl+P'
-                triggered :: experiment.pause_now()
         Action:
             text = 'End and Upload'
             triggered::experiment.end_now()


### PR DESCRIPTION
Have you ever paused an experiment and then tried to reset it, only for it to yell at you saying that it needed to be idle to reset? 

Have you ever then hit stop and reset your experiment, and then got annoyed when it paused right away because resetting a paused experiment didn't reset the pause settings?

Have you ever accidentally stopped an experiment and wanted to continue running it?

If you answered yes to any of these questions, this PR has the fix for you.

Also removes the unnecessary Pause_Now option from the menu as it was originally only intended as a work-around for the last question I mentioned. 