### PR TITLE
ROI analyses option

### DIFF
--- a/python/analysis.py
+++ b/python/analysis.py
@@ -792,8 +792,7 @@ class IterationsGraph(AnalysisWithFigure):
         if self.enable:  # and self.update_every_measurement:
             if (not self.add_only_filtered_data) or (('analysis/loading_filter' in measurementResults) and measurementResults['analysis/loading_filter'].value):
 
-                #d = np.array([measurementResults['analysis/squareROIsums']])
-                d = np.array([measurementResults['analysis/gaussian_roi']])
+                d = np.array([measurementResults['analysis/'+self.experiment.ROITypeString]])
 
                 if self.current_iteration_data is None:
                     # on first measurement of an iteration, start anew

--- a/python/experiments.py
+++ b/python/experiments.py
@@ -208,6 +208,7 @@ class Experiment(Prop):
     optimizer = Member()
     ivarBases = Member()
     instrument_update_needed = Bool(True)
+    ROITypeString = Str()
 
 
     # threading
@@ -266,6 +267,7 @@ class Experiment(Prop):
         self.ivarIndex = []
         self.vars = {}
         self.analyses = []
+        self.ROITypeString = 'gaussian_roi'  # used in analysis.py; can be overwritten by experiment classes
 
         self.properties += ['version', 'constantsStr', 'independentVariables', 'dependentVariablesStr',
                             'pauseAfterIteration', 'pauseAfterMeasurement', 'pauseAfterError',

--- a/python/rubidium.py
+++ b/python/rubidium.py
@@ -110,6 +110,7 @@ class Rb(Experiment):
 
         # analyses
         self.squareROIAnalysis = SquareROIAnalysis(self)
+        self.ROITypeString = 'squareROIsums'
         self.imageSumAnalysis = ImageSumAnalysis(self)
         self.TTL_filters = TTL.TTL_filters('TTL_filters', self)
         self.functional_waveforms_graph = functional_waveforms.FunctionalWaveformGraph('functional_waveforms_graph', self, 'Graph the HSDIO, DAQmx DO, and DAQmx AO settings')


### PR DESCRIPTION
A fix for a place in the analyses code where experiments would comment out one of two lines to properly run their experiment analysis. The discrepancy between experiments in question is a key for the measurementResults dict. Rather than continue using a hardcoded string as the dict key, I have added an attribute to the experiment class with the value that was used in the master branch, and overwritten the string in the rubidium experiment subclass. I have tested this change in Rb and it did not seem to break anything.