### PR TITLE
Feature load waveform file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ python/config/config.cfg
 *.cache
 *.db
 *.bak
+/python/exp_functional_waveforms/settings_waveform.py

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ python/config/config.cfg
 *.db
 *.bak
 /python/exp_functional_waveforms/settings_waveform.py
+/python/exp_functional_waveforms/rb_waveform.py

--- a/python/RbAIAnalysis.py
+++ b/python/RbAIAnalysis.py
@@ -11,6 +11,7 @@ created = '2014.09.08'
 modified >= '2014.09.08'
 modified >= '2017.05.04'
 modified >= '2018.10.22' CY
+modified >= '2021.01.21' CY
 """
 
 import logging
@@ -45,6 +46,10 @@ class RbAIAnalysis(Analysis):
     def analyzeMeasurement(self, measResults, iterationResults, experimentResults):
         if self.enable:
             raw_data = measResults['data/AI/data'].value
+
+            # to get data: raw_data[AI_channel_idx_on_the_card, range_of_sample_indices]
+
+            # 3D MOT arms powers from I2V curves
             Y1 = (13.0538+1.07403*(np.nanmean(raw_data[3,1:10])*1000))
             Y2 = (15.2633+1.03056*(np.nanmean(raw_data[4,1:10])*1000))
             X1 = (-5.48042+1.25244*(np.nanmean(raw_data[5,1:10])*1000))
@@ -55,6 +60,12 @@ class RbAIAnalysis(Analysis):
             MOTX = X1/X2 # x1-x2
             MOTY = Y1/Y2 # y1-y2
             MOTZ = Z1/Z2 # z1-z2"
+
+            # Sensor for B-fields in the Box
+            SBX = np.nanmean(raw_data[13,1:10])
+            SBY = np.nanmean(raw_data[14,1:10])
+            SBZ = np.nanmean(raw_data[15,1:10])
+
             logger.info('X1/X2 = {} Total X Power: {}'.format(MOTX, X1+X2))
             logger.info('Y1/Y2 = {} Total Y Power: {}'.format(MOTY, Y1+Y2))
             logger.info('Z1/Z2 = {} Total Z Power: {}'.format(MOTZ, Z1+Z2))
@@ -67,7 +78,10 @@ class RbAIAnalysis(Analysis):
             # MOTtot = np.nanmean(raw_data[9,1:10])
 
             processed_data = [MOTX, MOTY, MOTZ, MOTtot]
+
+            # add measurements to the measurement results
             measResults['analysis/processed_AI/data'] = processed_data
+            measResults['analysis/AI_magnetic_sensor_3axis'] = [SBX, SBY, SBZ]
             # hdf5['AI/test'] = 11.0
 
 

--- a/python/aqua.py
+++ b/python/aqua.py
@@ -62,7 +62,6 @@ class AQuA(Experiment):
     NIScopes = Member()
     RydHP = Member()
 
-    functional_waveforms = Member()
     functional_waveforms_graph = Member()
     TTL_filters = Member()
     AI_graph = Member()
@@ -139,7 +138,6 @@ class AQuA(Experiment):
         except:
             logger.warning("Blackfly client disabled,"
                            "install PyCapture2 module to enable")
-        self.functional_waveforms = functional_waveforms.FunctionalWaveforms('functional_waveforms', self, 'Waveforms for HSDIO, DAQmx DIO, and DAQmx AO; defined as functions')
         self.picomotors = picomotors.Picomotors('picomotors', self, 'Newport Picomotors')
         self.noise_eaters = noise_eaters.Noise_Eaters('noise_eaters', self,'rotating wave-plate noise eaters')
         self.BILT = BILT.BILTcards('BILT',self, 'BILT DC Voltage sources')

--- a/python/cs.py
+++ b/python/cs.py
@@ -187,3 +187,4 @@ if __name__ == '__main__':
         experiment = aqua.AQuA(**experiment_args)
     logger.info('Experiment built, building GUI')
     launch_gui_with_experiment(experiment)
+    experiment.functional_waveforms.load_from_settings = False

--- a/python/cs_GUI.enaml
+++ b/python/cs_GUI.enaml
@@ -28,7 +28,7 @@ from enaml.image import Image
 from enaml.core.declarative import d_
 from enaml.core.include import Include
 from enaml.stdlib.dialog_buttons import DialogButton
-from enaml.stdlib.message_box import question
+from enaml.stdlib.message_box import question, information
 from enaml.stdlib.fields import FloatField, IntField
 from enaml.core.api import Looper, Conditional
 from enaml.styling import StyleSheet, Style, Setter
@@ -242,13 +242,8 @@ enamldef CsMenuBar(MenuBar): menuBar:
         Action:
             text = 'Load\tCtrl+L'
             triggered::
-                dlg = FileDialog(
-                    parent=menuBar,
-                    title='Choose file to load',
-                    mode='open_file',
-                    path=experiment.setting_path,
-                    callback=get_load_file_callback(experiment),
-                    ).open()
+                confirm_load_file(menuBar, experiment)
+
         Action:
             text = 'Save\tCtrl+S'
             triggered::
@@ -4958,6 +4953,30 @@ def confirm_close(calling_window, event):
         event.accept()
     else:
         event.ignore()
+
+def confirm_load_file(parent, experiment):
+
+    dialog = question(
+    parent=None,
+    title='Load old experiment?',
+    text='Important: your waveform will now be read from the file you select. \n'
+     'To stop using the old waveform, uncheck "load from settings file" in FunctionalWaveforms',
+    buttons=[
+        DialogButton(
+                     text='Continue',
+                     action='accept'),
+        DialogButton(
+                     text='Nevermind',
+                     action='reject')]
+    )
+    if dialog and dialog.action == 'accept':
+        dlg = FileDialog(
+                    parent=parent,
+                    title='Choose file to load',
+                    mode='open_file',
+                    path=experiment.setting_path,
+                    callback=get_load_file_callback(experiment),
+                    ).open()
 
 enamldef Main(MainWindow): main:
     attr experiment

--- a/python/cs_GUI.enaml
+++ b/python/cs_GUI.enaml
@@ -1175,7 +1175,7 @@ enamldef FunctionalWaveforms(Window):
                     # waveform entry
                     hug_width = 'ignore'
                     hug_height = 'ignore'
-                    text := waveforms.field_text
+                    text := waveforms.text
 
 enamldef FunctionalWaveformsGraph(Window):
     attr graph

--- a/python/cs_GUI.enaml
+++ b/python/cs_GUI.enaml
@@ -1135,31 +1135,47 @@ enamldef FunctionalWaveforms(Window):
     Container:
         padding = 0
         style_class << 'valid' if experiment.valid else 'invalid'
-        ScrollArea:
+        constraints = [
+            form.bottom == enable.bottom + 50,
+            form.left == contents_left,
+            form.right == contents_right,
+            scroll.top == form.bottom,
+            scroll.bottom == contents_bottom,
+            scroll.left == contents_left,
+            scroll.right == contents_right,
+            enable.top == contents_top,
+            enable.bottom + 5 == form.top,
+            enable.left== contents_left + 5
+            ]
+
+
+        LabelBox: enable:
+            text = 'enable'
+            checked := waveforms.enable
+
+        Form: form:
             style_class << 'valid' if experiment.valid else 'invalid'
             Container:
                 style_class << 'valid' if experiment.valid else 'invalid'
-                constraints = [form.bottom+5 = field.top, enable.left==contents_left, enable.bottom+5==form.top, enable.top==contents_top, field.left==contents_left, field.right==contents_right, field.bottom==contents_bottom]
+                constraints = [box.left == contents_left, path.right == contents_right, path.left == box.right + 5]
+                LabelBox: box:
+                    text = 'Load Waveforms from File?'
+                    checked := waveforms.load_file
+                Field: path:
+                    text := waveforms.filename
+                    placeholder = 'Full path to waveform file'
 
-                LabelBox: enable:
-                    text = 'enable'
-                    checked := waveforms.enable
-
-                Form: form:
-                    constraints = [(midline==left)|'strong'] #,(width==parent.contents_width)|'strong']
-
-                    Label:
-                        text = 'Load Waveforms from File?'
-                    CheckField:
-                        checked := waveforms.load_file
-                        text := waveforms.filename
-                        placeholder = 'Full path to waveform file'
+        ScrollArea: scroll:
+            style_class << 'valid' if experiment.valid else 'invalid'
+            Container:
+                style_class << 'valid' if experiment.valid else 'invalid'
+                constraints = [field.top == contents_top, field.left==contents_left, field.right==contents_right, field.bottom==contents_bottom]
 
                 MultilineField: field:
                     # waveform entry
                     hug_width = 'ignore'
                     hug_height = 'ignore'
-                    text := waveforms.text
+                    text := waveforms.field_text
 
 enamldef FunctionalWaveformsGraph(Window):
     attr graph

--- a/python/cs_GUI.enaml
+++ b/python/cs_GUI.enaml
@@ -1145,7 +1145,7 @@ enamldef FunctionalWaveforms(Window):
             scroll.right == contents_right,
             enable.top == contents_top,
             enable.bottom + 5 == form.top,
-            enable.left == contents_left + 5
+            enable.left == contents_left + 5,
             settings.top == contents_top,
             settings.bottom + 5 == form.top,
             settings.left == enable.right + 5
@@ -1157,7 +1157,7 @@ enamldef FunctionalWaveforms(Window):
             checked := waveforms.enable
 
         LabelBox: settings:
-            text: 'load from settings file?'
+            text = 'load from settings file?'
             checked := waveforms.load_from_settings
 
         Form: form:

--- a/python/cs_GUI.enaml
+++ b/python/cs_GUI.enaml
@@ -1157,7 +1157,7 @@ enamldef FunctionalWaveforms(Window):
             checked := waveforms.enable
 
         LabelBox: settings:
-            text = 'load from settings file?'
+            text = 'load from settings file? (check when loading old experiments)'
             checked := waveforms.load_from_settings
 
         Form: form:

--- a/python/cs_GUI.enaml
+++ b/python/cs_GUI.enaml
@@ -4959,7 +4959,7 @@ def confirm_load_file(parent, experiment):
     dialog = question(
     parent=None,
     title='Load old experiment?',
-    text='Important: your waveform will now be read from the file you select. \n'
+    text='Important: your waveform will now be read from the hdf5 file you select. \n'
      'To stop using the old waveform, uncheck "load from settings file" in FunctionalWaveforms',
     buttons=[
         DialogButton(

--- a/python/cs_GUI.enaml
+++ b/python/cs_GUI.enaml
@@ -1139,7 +1139,7 @@ enamldef FunctionalWaveforms(Window):
             style_class << 'valid' if experiment.valid else 'invalid'
             Container:
                 style_class << 'valid' if experiment.valid else 'invalid'
-                constraints = [enable.left==contents_left, enable.bottom+5==field.top, enable.top==contents_top, field.left==contents_left, field.right==contents_right, field.bottom==contents_bottom]
+                constraints = [form.bottom+5 = field.top, enable.left==contents_left, enable.bottom+5==form.top, enable.top==contents_top, field.left==contents_left, field.right==contents_right, field.bottom==contents_bottom]
 
                 LabelBox: enable:
                     text = 'enable'

--- a/python/cs_GUI.enaml
+++ b/python/cs_GUI.enaml
@@ -1145,13 +1145,20 @@ enamldef FunctionalWaveforms(Window):
             scroll.right == contents_right,
             enable.top == contents_top,
             enable.bottom + 5 == form.top,
-            enable.left== contents_left + 5
+            enable.left == contents_left + 5
+            settings.top == contents_top,
+            settings.bottom + 5 == form.top,
+            settings.left == enable.right + 5
             ]
 
 
         LabelBox: enable:
             text = 'enable'
             checked := waveforms.enable
+
+        LabelBox: settings:
+            text: 'load from settings file?'
+            checked := waveforms.load_from_settings
 
         Form: form:
             style_class << 'valid' if experiment.valid else 'invalid'

--- a/python/cs_GUI.enaml
+++ b/python/cs_GUI.enaml
@@ -1145,6 +1145,16 @@ enamldef FunctionalWaveforms(Window):
                     text = 'enable'
                     checked := waveforms.enable
 
+                Form: form:
+                    constraints = [(midline==left)|'strong'] #,(width==parent.contents_width)|'strong']
+
+                    Label:
+                        text = 'Load Waveforms from File?'
+                    CheckField:
+                        checked := waveforms.load_file
+                        text := waveforms.filename
+                        placeholder = 'Full path to waveform file'
+
                 MultilineField: field:
                     # waveform entry
                     hug_width = 'ignore'

--- a/python/experiments.py
+++ b/python/experiments.py
@@ -831,13 +831,13 @@ class Experiment(Prop):
         if allow_evaluation_was_toggled:
             self.allow_evaluation = True
 
-        # now re-evaluate everything
-        self.evaluateAll()
-
-        # finally, check the load from settings box in functional waveforms to ensure the waveform
+        # check the load from settings box in functional waveforms to ensure the waveform
         # in the loaded file is the one that gets use
         if check_loaded_from_setting_box:
             self.functional_waveforms.load_from_settings = True
+
+        # now re-evaluate everything
+        self.evaluateAll()
 
     def measure(self):
         """Enables all instruments to begin a measurement.

--- a/python/fnode.py
+++ b/python/fnode.py
@@ -39,7 +39,6 @@ class FNODE(Experiment):
     DDS = Member()
     Embezzletron = Member()
 
-    functional_waveforms = Member()
     functional_waveforms_graph = Member()
     TTL_filters = Member()
     AI_graph = Member()
@@ -71,11 +70,6 @@ class FNODE(Experiment):
                                     cache_location=cache_location,
                                     settings_location=settings_location,
                                     temp_location=temp_location)
-        self.functional_waveforms = functional_waveforms.FunctionalWaveforms(
-            name='functional_waveforms',
-            experiment=self,
-            description='Waveforms for HSDIO, DAQmx DIO, and DAQmx AO;'
-                        ' defined as functions')
         self.Andors = andor.Andors(
             name='Andors',
             experiment=self,

--- a/python/functional_waveforms.py
+++ b/python/functional_waveforms.py
@@ -39,7 +39,7 @@ class FunctionalWaveforms(Instrument):
     """
     version = '2015.05.24'
 
-    SETTINGS_WAVEFORM = r"exp_functional_waveform\settings_waveform.py"
+    SETTINGS_WAVEFORM = os.path.join(os.getcwd(), r"exp_functional_waveforms\settings_waveform.py")
 
     waveform_text = Str()  # a text string that holds all the waveforms
     """ load_file : if true, waveforms text is loaded from a file, overwriting the text in the
@@ -63,7 +63,7 @@ class FunctionalWaveforms(Instrument):
 
         # Create the settings wavefrom file if it doesn't already exist
         if not os.path.isfile(self.SETTINGS_WAVEFORM):
-            with open(self.SETTINGS_WAVEFORM, "x") as f:
+            with open(self.SETTINGS_WAVEFORM, "w") as f:
                 f.write("")
 
     def evaluate(self):

--- a/python/functional_waveforms.py
+++ b/python/functional_waveforms.py
@@ -39,17 +39,17 @@ class FunctionalWaveforms(Instrument):
     """
     version = '2015.05.24'
 
-    text = Str()  # a text string that holds all the waveforms
+    waveform_text = Str()  # a text string that holds all the waveforms
     """ load_file : if true, waveforms text is loaded from a file, overwriting the text in the
     # text box """
     load_file = Bool()
     filename = Str()  # File from which to load functional waveforms if load_file is true.
     file_text = Str()  # Text loaded from a file
-    field_text = Str()  # Text string in the GUI field
+    text = Str()  # Text string in the GUI field
 
     def __init__(self, name, experiment, description=''):
         super(FunctionalWaveforms, self).__init__(name, experiment, description)
-        self.properties += ['version', 'text', 'file_text', 'field_text', 'load_file', 'filename']
+        self.properties += ['version', 'text', 'file_text', 'waveform_text', 'load_file', 'filename']
 
     def evaluate(self):
         if self.enable and self.experiment.allow_evaluation:
@@ -57,12 +57,12 @@ class FunctionalWaveforms(Instrument):
             self.experiment.LabView.HSDIO.repeat_list = []  # Prevents buildup
 
             # default to using the text in the input field as the waveform
-            self.text = self.field_text
+            self.waveform_text = self.text
 
             # If load_file is checked, overwrite waveform with text from a file
             if self.load_file and os.path.isfile(self.filename):
                 self.load_text_from_file()
-                self.text = self.file_text
+                self.waveform_text = self.file_text
             elif self.load_file:
                 logger.warning(
                     "load_file is true but filename is not a valid file, defaulting to text box waveform\n"
@@ -70,7 +70,7 @@ class FunctionalWaveforms(Instrument):
                 )
 
             #localvars = self.experiment.vars.copy()
-            cs_evaluate.execWithGlobalDict(self.text) #, localvars)
+            cs_evaluate.execWithGlobalDict(self.waveform_text) #, localvars)
 
             super(FunctionalWaveforms, self).evaluate()
 

--- a/python/functional_waveforms.py
+++ b/python/functional_waveforms.py
@@ -39,24 +39,30 @@ class FunctionalWaveforms(Instrument):
     """
     version = '2015.05.24'
 
-    text = Str()  # a text string that holds all the waveforms
+    waveform_text = Str()  # a text string that holds all the waveforms
     """ load_file : if true, waveforms text is loaded from a file, overwriting the text in the
     # text box """
     load_file = Bool()
     filename = Str()  # File from which to load functional waveforms if load_file is true.
+    file_text = Str()  # Text loaded from a file
+    field_text = Str()  # Text string in the GUI field
 
     def __init__(self, name, experiment, description=''):
         super(FunctionalWaveforms, self).__init__(name, experiment, description)
-        self.properties += ['version', 'text', 'load_file', 'filename']
+        self.properties += ['version', 'waveform_text', 'file_text', 'field_text', 'load_file', 'filename']
 
     def evaluate(self):
         if self.enable and self.experiment.allow_evaluation:
             logger.debug('FunctionalWaveforms.evaluate()')
             self.experiment.LabView.HSDIO.repeat_list = []  # Prevents buildup
 
+            # default to using the text in the input field as the waveform
+            self.waveform_text = self.field_text
+
             # If load_file is checked, overwrite waveform with text from a file
             if self.load_file and os.path.isfile(self.filename):
                 self.load_text_from_file()
+                self.waveform_text = self.file_text
             elif self.load_file:
                 logger.warning(
                     "load_file is true but filename is not a valid file, defaulting to text box waveform\n"
@@ -64,7 +70,7 @@ class FunctionalWaveforms(Instrument):
                 )
 
             #localvars = self.experiment.vars.copy()
-            cs_evaluate.execWithGlobalDict(self.text) #, localvars)
+            cs_evaluate.execWithGlobalDict(self.waveform_text) #, localvars)
 
             super(FunctionalWaveforms, self).evaluate()
 
@@ -84,7 +90,7 @@ class FunctionalWaveforms(Instrument):
             logger.exception("Uncaught exception. Waveform not updated\n{}".format(e))
             raise
         else:
-            self.text = txt
+            self.file_text = txt
 
 
 class FunctionalWaveformGraph(AnalysisWithFigure):

--- a/python/functional_waveforms.py
+++ b/python/functional_waveforms.py
@@ -39,7 +39,7 @@ class FunctionalWaveforms(Instrument):
     """
     version = '2015.05.24'
 
-    waveform_text = Str()  # a text string that holds all the waveforms
+    text = Str()  # a text string that holds all the waveforms
     """ load_file : if true, waveforms text is loaded from a file, overwriting the text in the
     # text box """
     load_file = Bool()
@@ -49,7 +49,7 @@ class FunctionalWaveforms(Instrument):
 
     def __init__(self, name, experiment, description=''):
         super(FunctionalWaveforms, self).__init__(name, experiment, description)
-        self.properties += ['version', 'waveform_text', 'file_text', 'field_text', 'load_file', 'filename']
+        self.properties += ['version', 'text', 'file_text', 'field_text', 'load_file', 'filename']
 
     def evaluate(self):
         if self.enable and self.experiment.allow_evaluation:
@@ -57,12 +57,12 @@ class FunctionalWaveforms(Instrument):
             self.experiment.LabView.HSDIO.repeat_list = []  # Prevents buildup
 
             # default to using the text in the input field as the waveform
-            self.waveform_text = self.field_text
+            self.text = self.field_text
 
             # If load_file is checked, overwrite waveform with text from a file
             if self.load_file and os.path.isfile(self.filename):
                 self.load_text_from_file()
-                self.waveform_text = self.file_text
+                self.text = self.file_text
             elif self.load_file:
                 logger.warning(
                     "load_file is true but filename is not a valid file, defaulting to text box waveform\n"
@@ -70,7 +70,7 @@ class FunctionalWaveforms(Instrument):
                 )
 
             #localvars = self.experiment.vars.copy()
-            cs_evaluate.execWithGlobalDict(self.waveform_text) #, localvars)
+            cs_evaluate.execWithGlobalDict(self.text) #, localvars)
 
             super(FunctionalWaveforms, self).evaluate()
 

--- a/python/functional_waveforms.py
+++ b/python/functional_waveforms.py
@@ -37,7 +37,7 @@ class FunctionalWaveforms(Instrument):
 
 
     """
-    version = '2015.05.24'
+    version = '2020.12.17'
 
     SETTINGS_WAVEFORM = os.path.join(os.getcwd(), r"exp_functional_waveforms\settings_waveform.py")
 
@@ -129,6 +129,14 @@ class FunctionalWaveforms(Instrument):
         else:
             self.file_text = txt
 
+    def fromHDF5(self, hdf):
+        placeholder = "Placeholder"
+        self.waveform_text = placeholder
+        super(FunctionalWaveforms, self).fromHDF5(hdf)
+        # This indicates that the waveform_text attribute did not exist in the hdf5 file.
+        if self.waveform_text == placeholder:
+            # we overwrite the text with the text used to generate the waveform in the file.
+            self.waveform_text = self.text
 
 class FunctionalWaveformGraph(AnalysisWithFigure):
     """

--- a/python/holmium.py
+++ b/python/holmium.py
@@ -25,7 +25,6 @@ class HOLMIUM(Experiment):
     DDS = Member()
     unlock_pause = Member()
 
-    functional_waveforms = Member()
     functional_waveforms_graph = Member()
     AI_graph = Member()
     AI_filter = Member()
@@ -44,7 +43,6 @@ class HOLMIUM(Experiment):
                                    settings_location=settings_location,
                                    temp_location=temp_location)
 
-        self.functional_waveforms = functional_waveforms.FunctionalWaveforms('functional_waveforms', self, 'Waveforms for HSDIO, DAQmx DIO, and DAQmx AO; defined as functions')
         self.Andors = andor.Andors('Andors', self, 'Andor Luca measurementResults')
         self.PICams = picampython.PICams('PICams', self, 'Princeton Instruments Cameras')
         self.DAQmxAI = nidaq_ai.NIDAQmxAI('DAQmxAI', self, 'NI-DAQmx Analog Input')

--- a/python/hybrid.py
+++ b/python/hybrid.py
@@ -47,7 +47,6 @@ class Hybrid(Experiment):
 
 
     thresholdROIAnalysis = Member()
-    functional_waveforms = Member()
     functional_waveforms_graph = Member()
     TTL_filters = Member()
     AI_graph = Member()
@@ -113,7 +112,6 @@ class Hybrid(Experiment):
             logger.warning("Blackfly client disabled,"
                            "install PyCapture2 module to enable")
 
-        self.functional_waveforms = functional_waveforms.FunctionalWaveforms('functional_waveforms', self, 'Waveforms for HSDIO, DAQmx DIO, and DAQmx AO; defined as functions')
         self.Andors = andor.Andors('Andors', self, 'Andor Luca measurementResults')
         self.DAQmxAI = nidaq_ai.NIDAQmxAI('DAQmxAI', self, 'NI-DAQmx Analog Input')
         self.NewportStage = newportstage.NewportStage('NewportStage', self, 'Newport Translation Stage')

--- a/python/rubidium.py
+++ b/python/rubidium.py
@@ -36,7 +36,6 @@ class Rb(Experiment):
     DDS2 = Member()
     pyPicoServer = Member()
     imageSumAnalysis = Member()
-    functional_waveforms = Member()
     functional_waveforms_graph = Member()
     DAQmxAI = Member()
     beam_position_analysis = Member()
@@ -88,7 +87,7 @@ class Rb(Experiment):
         except:
             logger.warning("Blackfly client disabled,"
                            "install PyCapture2 module to enable")
-        self.functional_waveforms = functional_waveforms.FunctionalWaveforms('functional_waveforms', self, 'Waveforms for HSDIO, DAQmx DIO, and DAQmx AO; defined as functions')
+        # self.functional_waveforms = functional_waveforms.FunctionalWaveforms('functional_waveforms', self, 'Waveforms for HSDIO, DAQmx DIO, and DAQmx AO; defined as functions')
 
         self.Andors = andor.Andors('Andors', self, 'Andor Luca measurementResults')
         self.LabView = LabView.LabView(self)

--- a/rb_ai_chans.txt
+++ b/rb_ai_chans.txt
@@ -1,0 +1,22 @@
+# Rb experiment Analog Input channel definitions
+# this does not define the channel indices, it just lists the physical AI card channel numbers associated with the
+# detectors they monitor at the time of writing this. Hence, this is subject to change
+
+# channel, thing being monitored, name/date
+
+0, 780A I2V, PH 2020.01.21
+1, 480 I2V, PH 2020.01.21
+2, FORT I2V, PH 2020.01.21
+3, 3D MOT Y1, PH 2020.01.21
+4, 3D MOT Y2, PH 2020.01.21
+5, 3D MOT X1, PH 2020.01.21
+6, 3D MOT X2, PH 2020.01.21
+7, 3D MOT Z1, PH 2020.01.21
+8, 3D MOT Z2, PH 2020.01.21
+9,
+10,
+11,
+12,
+13, Box B-field sensor X, PH 2020.01.21
+14, Box B-field sensor Y, PH 2020.01.21
+15, Box B-field sensor Z, PH 2020.01.21


### PR DESCRIPTION
Adds a feature to the functional waveforms where you can load the waveforms from a file containing text that would otherwise be placed inside the functional waveforms text field.

I have tested the feature using a full path to the file, but I suspect a relative path should also work.

The text in the file, the text in the field and the text used to generate waveforms are all saved separately in HDF5 files as `file_text`, `text` and `waveform_text` respectively. `waveform_text` will always be a copy of either `file_text` or `text`.